### PR TITLE
correction des lettres jaunes

### DIFF
--- a/src/Service/ColorManager.php
+++ b/src/Service/ColorManager.php
@@ -15,22 +15,24 @@ class ColorManager
     {
         $result = [];
         $valids = [];
+        $nbYellowInResult = [];
         for ($i=0; $i<strlen($attempt); $i++) {
             if ($attempt[$i] === $expected[$i]) {
                 $result[] = 'green';
                 $valids[] = $attempt[$i];
                 $this->valids[] = $attempt[$i];
+                $nbYellowInResult[$attempt[$i]] = $nbYellowInResult[$attempt[$i]] ?? 0;
+                $nbYellowInResult[$attempt[$i]]++;
             } else {
                 $result[] = 'blue';
                 $this->errors[] = $attempt[$i];
             }
         }
-        $nbYellowInResult = [];
         for ($i=0; $i<strlen($attempt); $i++) {
-            if ($attempt[$i] !== $expected[$i] && !in_array($attempt[$i], $valids)) {
+            if ($attempt[$i] !== $expected[$i]) {
                 if (in_array($attempt[$i], str_split($expected))) {
-                    $nbYellowInResult[$attempt[$i]] = $nbYellowInResult[$attempt[$i]] ?? 1;
-                    if ($nbYellowInResult[$attempt[$i]] <= array_count_values(str_split($expected))[$attempt[$i]]) {
+                   $nbYellowInResult[$attempt[$i]] = $nbYellowInResult[$attempt[$i]] ?? 0;
+                    if ($nbYellowInResult[$attempt[$i]] < array_count_values(str_split($expected))[$attempt[$i]]) {
                         $result[$i] = 'yellow';
                         $this->aways[] = $attempt[$i];
                         $nbYellowInResult[$attempt[$i]]++;


### PR DESCRIPTION
Si la lettre est présente plus d'une fois dans le mot proposé et dans la solution et qu'elle est placée une fois correctement et une fois incorrectement, elle doit apparaître une fois en vert et une fois en jaune. Actuellement la lettre mal placée apparaît en bleu, on ne sait donc pas que la lettre est deux fois dans la solution même si on l'a mise deux fois dans la proposition.

Correction proposée : les lettres bien placées doivent compter comme "en jaune" dans la première passe.

Je n'ai pas fait de PHP depuis très longtemps, j'ai testé dans une sandbox ici : http://sandbox.onlinephpfunctions.com/code/295769abe927db9e8643eb3513e60c743ac4e634 